### PR TITLE
Create a provisioner state for provision tracking

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/GoalViolationDetector.java
@@ -228,8 +228,8 @@ public class GoalViolationDetector extends AbstractAnomalyDetector implements Ru
       _provisionResponse = provisionResponse;
       if (_isProvisionerEnabled) {
         // Right-size the cluster (if needed)
-        boolean isRightsized = _provisioner.rightsize(_provisionResponse.recommendationByRecommender());
-        if (isRightsized) {
+        ProvisionerState isRightsized = _provisioner.rightsize(_provisionResponse.recommendationByRecommender());
+        if (isRightsized.state() == ProvisionerState.State.IN_PROGRESS) {
           LOG.info("Actions have been taken on the cluster towards rightsizing.");
         }
       }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/NoopProvisioner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/NoopProvisioner.java
@@ -13,8 +13,8 @@ import java.util.Map;
  */
 public class NoopProvisioner implements Provisioner {
   @Override
-  public boolean rightsize(Map<String, ProvisionRecommendation> recommendationByRecommender) {
-    return false;
+  public ProvisionerState rightsize(Map<String, ProvisionRecommendation> recommendationByRecommender) {
+    return new ProvisionerState(ProvisionerState.State.COMPLETE, null);
   }
 
   @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/Provisioner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/Provisioner.java
@@ -31,7 +31,7 @@ public interface Provisioner extends CruiseControlConfigurable {
    * </ul>
    *
    * @param recommendationByRecommender Provision recommendations provided by corresponding recommenders.
-   * @return {@code true} if actions have been taken on the cluster towards rightsizing, {@code false} otherwise.
+   * @return ProvisionerState of actions taken on the cluster towards rightsizing.
    */
-  boolean rightsize(Map<String, ProvisionRecommendation> recommendationByRecommender);
+  ProvisionerState rightsize(Map<String, ProvisionRecommendation> recommendationByRecommender);
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ProvisionerState.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ProvisionerState.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+/**
+ * A class to indicate how a provision is handled
+ */
+public class ProvisionerState {
+  private State _state;
+  private String _summary;
+  private final long _createdMs;
+  private long _updatedMs;
+
+  public ProvisionerState(State state, String summary) {
+    _state = state;
+    _summary = summary;
+    _createdMs = System.currentTimeMillis();
+    _updatedMs = _createdMs;
+  }
+
+  /**
+   * @return The state of the provisioning action.
+   */
+  public State state() {
+    return _state;
+  }
+
+  /**
+   * @return The summary of the provisioning action status.
+   */
+  public String summary() {
+    return _summary;
+  }
+
+  /**
+   * @return The time the provisioner state was created in milliseconds.
+   */
+  public long createdMs() {
+    return _createdMs;
+  }
+
+  /**
+   * @return The status update time of the provision state in milliseconds.
+   */
+  public long updateMs() {
+    return _updatedMs;
+  }
+
+  /**
+   * Set the state of the provisioning action
+   *
+   * @param state The new state of the provisioning action.
+   */
+  public void setState(State state) {
+    _state = state;
+    _updatedMs = System.currentTimeMillis();
+  }
+
+  /**
+   * Set the summary of the provisioning action
+   *
+   * @param summary The new summary of the provisioning action status.
+   */
+  public void setSummary(String summary) {
+    _summary = summary;
+    _updatedMs = System.currentTimeMillis();
+  }
+
+  public enum State {
+    COMPLETE, COMPLETED_WITH_ERROR, IN_PROGRESS
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ProvisionerUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/ProvisionerUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.detector;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+
+import static com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils.maybeIncreasePartitionCount;
+
+/**
+ * A util class for provisions.
+ */
+public final class ProvisionerUtils {
+
+  private ProvisionerUtils() {
+  }
+
+  /**
+   * Determine the status of increasing the partition count
+   *
+   * @param adminClient AdminClient to handle partition update requests.
+   * @param provisionerTopic Existing topic to add more partitions if needed
+   * @return The state COMPLETE when true, COMPLETED_WITH_EXCEPTION when false
+   */
+  public static ProvisionerState partitionIncreaseStatus(AdminClient adminClient, NewTopic provisionerTopic) {
+    if (maybeIncreasePartitionCount(adminClient, provisionerTopic)) {
+      String summary = "Provisioning the partition with the topic " + provisionerTopic.name() + " was successfully completed.";
+      return new ProvisionerState(ProvisionerState.State.COMPLETE, summary);
+    } else {
+      String summary = "Provisioning the partition with the topic " + provisionerTopic.name() + " was rejected.";
+      return new ProvisionerState(ProvisionerState.State.COMPLETED_WITH_ERROR, summary);
+    }
+  }
+}


### PR DESCRIPTION
A ProvisionerState is created to provide a more detailed response with progress tracking when rightsizing the cluster.
The ProvisionerUtils.partitionIncreaseStatus() can be found duplicated in Likafka-cruise-control.
Testing is in progress.