### PR TITLE
Setup a test endpoint for Rightsizing

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlParametersConfig.java
@@ -19,6 +19,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.parameters.RebalanceParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.RemoveBrokerParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewBoardParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.ReviewParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.StopProposalParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.TopicConfigurationParameters;
 import com.linkedin.kafka.cruisecontrol.servlet.parameters.TrainParameters;
@@ -171,6 +172,13 @@ public final class CruiseControlParametersConfig {
   public static final String DEFAULT_TOPIC_CONFIGURATION_PARAMETERS_CLASS = TopicConfigurationParameters.class.getName();
   public static final String TOPIC_CONFIGURATION_PARAMETERS_CLASS_DOC = "The class for parameters of a topic configuration request.";
 
+  /**
+   * <code>rightsize.parameters.class</code>
+   */
+  public static final String RIGHTSIZE_PARAMETERS_CLASS_CONFIG = "rightsize.parameters.class";
+  public static final String DEFAULT_RIGHTSIZE_PARAMETERS_CLASS = RightsizeParameters.class.getName();
+  public static final String RIGHTSIZE_PARAMETERS_CLASS_DOC = "The class for testing rightsizing requests.";
+
   private CruiseControlParametersConfig() {
   }
 
@@ -280,6 +288,11 @@ public final class CruiseControlParametersConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_TOPIC_CONFIGURATION_PARAMETERS_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            TOPIC_CONFIGURATION_PARAMETERS_CLASS_DOC);
+                            TOPIC_CONFIGURATION_PARAMETERS_CLASS_DOC)
+                    .define(RIGHTSIZE_PARAMETERS_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_RIGHTSIZE_PARAMETERS_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            RIGHTSIZE_PARAMETERS_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/CruiseControlRequestConfig.java
@@ -13,6 +13,7 @@ import com.linkedin.kafka.cruisecontrol.servlet.handler.async.PartitionLoadReque
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.ProposalsRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RebalanceRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RemoveBrokerRequest;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.RightsizeRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.TopicConfigurationRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.AdminRequest;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.sync.BootstrapRequest;
@@ -173,6 +174,13 @@ public final class CruiseControlRequestConfig {
   public static final String DEFAULT_TOPIC_CONFIGURATION_REQUEST_CLASS = TopicConfigurationRequest.class.getName();
   public static final String TOPIC_CONFIGURATION_REQUEST_CLASS_DOC = "The class to handle a topic configuration request.";
 
+  /**
+   * <code>rightsize.request.class</code>
+   */
+  public static final String RIGHTSIZE_REQUEST_CLASS_CONFIG = "rightsize.request.class";
+  public static final String DEFAULT_RIGHTSIZE_REQUEST_CLASS = RightsizeRequest.class.getName();
+  public static final String RIGHTSIZE_REQUEST_CLASS_DOC = "The class to handle testing a resizing request";
+
   private CruiseControlRequestConfig() {
   }
 
@@ -282,6 +290,11 @@ public final class CruiseControlRequestConfig {
                             ConfigDef.Type.CLASS,
                             DEFAULT_TOPIC_CONFIGURATION_REQUEST_CLASS,
                             ConfigDef.Importance.MEDIUM,
-                            TOPIC_CONFIGURATION_REQUEST_CLASS_DOC);
+                            TOPIC_CONFIGURATION_REQUEST_CLASS_DOC)
+                    .define(RIGHTSIZE_REQUEST_CLASS_CONFIG,
+                            ConfigDef.Type.CLASS,
+                            DEFAULT_RIGHTSIZE_REQUEST_CLASS,
+                            ConfigDef.Importance.MEDIUM,
+                            RIGHTSIZE_REQUEST_CLASS_DOC);
   }
 }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/CruiseControlEndPoint.java
@@ -33,7 +33,8 @@ public enum CruiseControlEndPoint implements EndPoint {
   REVIEW_BOARD(CRUISE_CONTROL_MONITOR),
   ADMIN(CRUISE_CONTROL_ADMIN),
   REVIEW(CRUISE_CONTROL_ADMIN),
-  TOPIC_CONFIGURATION(KAFKA_ADMIN);
+  TOPIC_CONFIGURATION(KAFKA_ADMIN),
+  RIGHTSIZE(KAFKA_ADMIN);
 
   private static final List<CruiseControlEndPoint> CACHED_VALUES = Collections.unmodifiableList(Arrays.asList(values()));
   private static final List<CruiseControlEndPoint> GET_ENDPOINTS = Arrays.asList(BOOTSTRAP,
@@ -55,7 +56,8 @@ public enum CruiseControlEndPoint implements EndPoint {
                                                                                   DEMOTE_BROKER,
                                                                                   ADMIN,
                                                                                   REVIEW,
-                                                                                  TOPIC_CONFIGURATION);
+                                                                                  TOPIC_CONFIGURATION,
+                                                                                  RIGHTSIZE);
 
   private final EndpointType _endpointType;
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletUtils.java
@@ -111,6 +111,9 @@ public final class KafkaCruiseControlServletUtils {
     RequestParameterWrapper topicConfiguration = new RequestParameterWrapper(TOPIC_CONFIGURATION_PARAMETERS_CLASS_CONFIG,
                                                                              TOPIC_CONFIGURATION_PARAMETER_OBJECT_CONFIG,
                                                                              TOPIC_CONFIGURATION_REQUEST_CLASS_CONFIG);
+    RequestParameterWrapper rightsize = new RequestParameterWrapper(RIGHTSIZE_PARAMETERS_CLASS_CONFIG,
+                                                                    RIGHTSIZE_PARAMETER_OBJECT_CONFIG,
+                                                                    RIGHTSIZE_REQUEST_CLASS_CONFIG);
 
     requestParameterConfigs.put(BOOTSTRAP, bootstrap);
     requestParameterConfigs.put(TRAIN, train);
@@ -132,6 +135,7 @@ public final class KafkaCruiseControlServletUtils {
     requestParameterConfigs.put(REVIEW, review);
     requestParameterConfigs.put(REVIEW_BOARD, reviewBoard);
     requestParameterConfigs.put(TOPIC_CONFIGURATION, topicConfiguration);
+    requestParameterConfigs.put(RIGHTSIZE, rightsize);
 
     REQUEST_PARAMETER_CONFIGS = Collections.unmodifiableMap(requestParameterConfigs);
   }

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RightsizeRequest.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/RightsizeRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async;
+
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.OperationFuture;
+import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.RightsizeRunnable;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
+import java.util.Map;
+
+import static com.linkedin.cruisecontrol.common.utils.Utils.validateNotNull;
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.RIGHTSIZE_PARAMETER_OBJECT_CONFIG;
+
+
+public class RightsizeRequest extends AbstractAsyncRequest {
+  protected RightsizeParameters _parameters;
+
+  public RightsizeRequest() {
+    super();
+  }
+
+  @Override
+  protected OperationFuture handle(String uuid) {
+    OperationFuture future = new OperationFuture("Rightsize");
+    pending(future.operationProgress());
+    _asyncKafkaCruiseControl.sessionExecutor().submit(new RightsizeRunnable(_asyncKafkaCruiseControl, future, _parameters));
+    return future;
+  }
+
+  @Override
+  public RightsizeParameters parameters() {
+    return _parameters;
+  }
+
+  @Override
+  public String name() {
+    return RightsizeRequest.class.getSimpleName();
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    super.configure(configs);
+    _parameters = (RightsizeParameters) validateNotNull(configs.get(RIGHTSIZE_PARAMETER_OBJECT_CONFIG),
+                                                     "Parameter configuration is missing from the request.");
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RightsizeRunnable.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/handler/async/runnable/RightsizeRunnable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable;
+
+import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
+import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionRecommendation;
+import com.linkedin.kafka.cruisecontrol.analyzer.ProvisionStatus;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.config.constants.AnomalyDetectorConfig;
+import com.linkedin.kafka.cruisecontrol.detector.Provisioner;
+import com.linkedin.kafka.cruisecontrol.detector.ProvisionerState;
+import com.linkedin.kafka.cruisecontrol.servlet.parameters.RightsizeParameters;
+import com.linkedin.kafka.cruisecontrol.servlet.response.RightsizeResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.linkedin.kafka.cruisecontrol.detector.AnomalyDetectorUtils.KAFKA_CRUISE_CONTROL_OBJECT_CONFIG;
+
+/**
+ * The async runnable for testing resizing
+ */
+public class RightsizeRunnable extends OperationRunnable {
+  private static final String RECOMMENDER_UP = "Recommender-Under-Provisioned";
+  protected final RightsizeParameters _parameters;
+
+  public RightsizeRunnable(KafkaCruiseControl kafkaCruiseControl, OperationFuture future, RightsizeParameters parameters) {
+    super(kafkaCruiseControl, future);
+    _parameters = parameters;
+  }
+
+  @Override
+  protected RightsizeResult getResult() throws Exception {
+    KafkaCruiseControlConfig config = _kafkaCruiseControl.config();
+    Map<String, Object> overrideConfigs;
+    overrideConfigs = Collections.singletonMap(KAFKA_CRUISE_CONTROL_OBJECT_CONFIG, _kafkaCruiseControl);
+    Provisioner provisioner = config.getConfiguredInstance(AnomalyDetectorConfig.PROVISIONER_CLASS_CONFIG,
+                                                         Provisioner.class,
+                                                         overrideConfigs);
+    Map<String, ProvisionRecommendation> provisionRecommendation = new HashMap<>();
+    ProvisionRecommendation recommendation =
+        new ProvisionRecommendation.Builder(ProvisionStatus.UNDER_PROVISIONED).numBrokers(_parameters.brokerDiff())
+                                                                              .numPartitions(_parameters.partitionCount())
+                                                                              .topic(_parameters.topicName())
+                                                                              .build();
+    provisionRecommendation.put(RECOMMENDER_UP, recommendation);
+    ProvisionerState rightsizeResults = provisioner.rightsize(provisionRecommendation);
+
+    return new RightsizeResult(_parameters.brokerDiff(), _parameters.partitionCount(), _parameters.topicName(), rightsizeResults, config);
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -59,7 +59,6 @@ import static com.linkedin.kafka.cruisecontrol.servlet.purgatory.ReviewStatus.DI
 import static com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils.writeErrorResponse;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
-
 /**
  * The util class for Kafka Cruise Control parameters.
  */
@@ -138,6 +137,9 @@ public final class ParameterUtils {
   public static final String TOPIC_BY_REPLICATION_FACTOR = "topic_by_replication_factor";
   public static final String NO_REASON_PROVIDED = "No reason provided";
   public static final String DO_AS = "doAs";
+  public static final String BROKER_DIFF = "broker_diff";
+  public static final String PARTITION_COUNT = "partition_count";
+  public static final String TOPIC_NAME = "topic_name";
 
   public static final String STOP_PROPOSAL_PARAMETER_OBJECT_CONFIG = "stop.proposal.parameter.object";
   public static final String BOOTSTRAP_PARAMETER_OBJECT_CONFIG = "bootstrap.parameter.object";
@@ -158,6 +160,7 @@ public final class ParameterUtils {
   public static final String ADMIN_PARAMETER_OBJECT_CONFIG = "admin.parameter.object";
   public static final String REVIEW_PARAMETER_OBJECT_CONFIG = "review.parameter.object";
   public static final String TOPIC_CONFIGURATION_PARAMETER_OBJECT_CONFIG = "topic.configuration.parameter.object";
+  public static final String RIGHTSIZE_PARAMETER_OBJECT_CONFIG = "rightsize.parameter.object";
 
   private ParameterUtils() {
   }
@@ -919,6 +922,38 @@ public final class ParameterUtils {
       throw new UserRequestException("The " + PARTITION_PARAM + " parameter cannot contain multiple dashes.");
     }
     return Integer.parseInt(boundaries[isUpperBound ? 1 : 0]);
+  }
+
+  /**
+   * Get the {@link #BROKER_DIFF} from the request.
+   *
+   * Default: -1
+   * @return The value of {@link #BROKER_DIFF} parameter.
+   */
+  static int brokerDiff(HttpServletRequest request) {
+    String parameterString = caseSensitiveParameterName(request.getParameterMap(), BROKER_DIFF);
+    return parameterString == null ? -1 : Integer.parseInt(request.getParameter(parameterString));
+  }
+
+  /**
+   * Get the {@link #PARTITION_COUNT} from the request.
+   *
+   * Default: -1
+   * @return The value of {@link #PARTITION_COUNT} parameter.
+   */
+  static int partitionCount(HttpServletRequest request) {
+    String parameterString = caseSensitiveParameterName(request.getParameterMap(), PARTITION_COUNT);
+    return parameterString == null ? -1 : Integer.parseInt(request.getParameter(parameterString));
+  }
+
+  /**
+   * Get the {@link #TOPIC_NAME} from the request.
+   *
+   * @return The value of {@link #TOPIC_NAME} parameter,
+   */
+  public static String topicName(HttpServletRequest request) {
+    String parameterString = caseSensitiveParameterName(request.getParameterMap(), TOPIC_NAME);
+    return request.getParameter(parameterString);
   }
 
   static Set<Integer> brokerIds(HttpServletRequest request, boolean isOptional) throws UnsupportedEncodingException {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RightsizeParameters.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/RightsizeParameters.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.parameters;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static com.linkedin.kafka.cruisecontrol.servlet.parameters.ParameterUtils.*;
+
+
+public class RightsizeParameters extends AbstractParameters {
+  protected static final SortedSet<String> CASE_INSENSITIVE_PARAMETER_NAMES;
+  static {
+    SortedSet<String> validParameterNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    validParameterNames.add(BROKER_DIFF);
+    validParameterNames.add(PARTITION_COUNT);
+    validParameterNames.add(TOPIC_NAME);
+    validParameterNames.addAll(KafkaOptimizationParameters.CASE_INSENSITIVE_PARAMETER_NAMES);
+    CASE_INSENSITIVE_PARAMETER_NAMES = Collections.unmodifiableSortedSet(validParameterNames);
+  }
+  protected int _brokerDiff;
+  protected int _partitionCount;
+  protected String _topicName;
+
+  public RightsizeParameters() {
+    super();
+  }
+
+  @Override
+  protected void initParameters() throws UnsupportedEncodingException {
+    super.initParameters();
+    _brokerDiff = ParameterUtils.brokerDiff(_request);
+    _partitionCount = ParameterUtils.partitionCount(_request);
+    _topicName = ParameterUtils.topicName(_request);
+  }
+
+  public int brokerDiff() {
+    return _brokerDiff;
+  }
+
+  public int partitionCount() {
+    return _partitionCount;
+  }
+
+  public String topicName() {
+    return _topicName;
+  }
+
+  @Override
+  public SortedSet<String> caseInsensitiveParameterNames() {
+    return CASE_INSENSITIVE_PARAMETER_NAMES;
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/RightsizeResult.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/response/RightsizeResult.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet.response;
+
+import com.google.gson.Gson;
+import com.linkedin.cruisecontrol.servlet.parameters.CruiseControlParameters;
+import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.detector.ProvisionerState;
+import java.util.HashMap;
+import java.util.Map;
+
+
+
+@JsonResponseClass
+public class RightsizeResult extends AbstractCruiseControlResponse {
+  @JsonResponseField
+  protected static final String BROKER_DIFF = "broker-diff";
+  @JsonResponseField
+  protected static final String PARTITION_COUNT = "partition-count";
+  @JsonResponseField
+  protected static final String TOPIC_NAME = "topic-name";
+  @JsonResponseField
+  protected static final String PROVISION_STATE = "provision-state";
+  @JsonResponseField
+  protected static final String PROVISION_SUMMARY = "provision-summary";
+
+  protected final int _brokerDiff;
+  protected final int _partitionCount;
+  protected String _topicName;
+  protected String _provisionState;
+  protected String _provisionSummary;
+
+  public RightsizeResult(int brokerDiff, int partitionCount, String topicName, ProvisionerState provisionerState, KafkaCruiseControlConfig config) {
+    super(config);
+    _brokerDiff = brokerDiff;
+    _partitionCount = partitionCount;
+    _topicName = topicName;
+    _provisionState = provisionerState.state().toString();
+    _provisionSummary = provisionerState.summary();
+  }
+
+  protected String getJSONString() {
+    Map<String, Object> jsonStructure = new HashMap<>(5);
+    jsonStructure.put(BROKER_DIFF, _brokerDiff);
+    jsonStructure.put(PARTITION_COUNT, _partitionCount);
+    if (_topicName != null && !_topicName.isEmpty()) {
+      jsonStructure.put(TOPIC_NAME, _topicName);
+    }
+    if (_provisionState != null && !_provisionState.isEmpty()) {
+      jsonStructure.put(PROVISION_STATE, _provisionState);
+    }
+    if (_provisionSummary != null && !_provisionSummary.isEmpty()) {
+      jsonStructure.put(PROVISION_SUMMARY, _provisionSummary);
+    }
+    Gson gson = new Gson();
+    return gson.toJson(jsonStructure);
+  }
+
+  @Override
+  protected void discardIrrelevantAndCacheRelevant(CruiseControlParameters parameters) {
+    _cachedResponse = getJSONString();
+    // Discard irrelevant response.
+    _topicName = null;
+    _provisionState = null;
+    _provisionSummary = null;
+  }
+}

--- a/cruise-control/src/yaml/base.yaml
+++ b/cruise-control/src/yaml/base.yaml
@@ -28,6 +28,8 @@ paths:
     $ref: 'endpoints/rebalance.yaml#/RebalanceEndpoint'
   /kafkacruisecontrol/remove_broker:
     $ref: 'endpoints/removeBroker.yaml#/RemoveBrokerEndpoint'
+  /kafkacruisecontrol/rightsize:
+    $ref: 'endpoints/rightsize.yaml#/RightsizeEndpoint'
   /kafkacruisecontrol/resume_sampling:
     $ref: 'endpoints/resumeSampling.yaml#/ResumeSamplingEndpoint'
   /kafkacruisecontrol/review:

--- a/cruise-control/src/yaml/endpoints/rightsize.yaml
+++ b/cruise-control/src/yaml/endpoints/rightsize.yaml
@@ -1,0 +1,89 @@
+RightsizeEndpoint:
+  post:
+    operationId: rightsize
+    summary: Test the provisioner on Azure
+    parameters:
+      - name: broker_diff
+        in: query
+        description: The difference in broker count to rightsize towards.
+        schema:
+          type: integer
+          format: int32
+          default: -1
+      - name: partition_count
+        in: query
+        description: The target number of partitions to rightsize towards.
+        schema:
+          type: integer
+          format: int32
+          default: -1
+      - name: topic_name
+        in: query
+        description: The topic name of the partition resource to be rightsized.
+        schema:
+          type: string
+          default: null
+      - name: allow_capacity_estimation
+        in: query
+        description: Whether to allow capacity estimation when cruise-control is unable to obtain all per-broker capacity information.
+        schema:
+          type: boolean
+          default: true
+      - name: doAs
+        in: query
+        description: The user specified by a trusted proxy in that authentication model.
+        schema:
+          type: string
+      - name: exclude_recently_demoted_brokers
+        in: query
+        description: Whether to allow leader replicas to be moved to recently demoted brokers.
+        schema:
+          type: boolean
+          default: false
+      - name: get_response_schema
+        in: query
+        description: Whether to return JSON schema in response header or not.
+        schema:
+          type: boolean
+          default: false
+      - name: json
+        in: query
+        description: Whether to return in JSON format or not.
+        schema:
+          type: boolean
+          default: false
+      - name: verbose
+        in: query
+        description: Return detailed state information.
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful add brokers response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/optimizationResult.yaml#/OptimizationResult'
+          text/plain:
+            schema:
+              type: string
+      '202':
+        description: Add brokers in progress.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/progressResult.yaml#/ProgressResult'
+          text/plain:
+            schema:
+              type: string
+      # Response for all errors
+      default:
+        description: Error response.
+        content:
+          application/json:
+            schema:
+              $ref: '../responses/errorResponse.yaml#/ErrorResponse'
+          text/plain:
+            schema:
+              type: string


### PR DESCRIPTION
Create a test endpoint for integration testing with the Provisioner `rightsize` method. The endpoint will take in the `broker_diff`, `partition_count`, and `topic_name` that are targeted for rightsizing and return the `ProvisionerState` results.